### PR TITLE
Add interactive HTTP replay

### DIFF
--- a/cmd/pcapreplay/main.go
+++ b/cmd/pcapreplay/main.go
@@ -1,9 +1,16 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
+	"crypto/tls"
 	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"time"
 
+	"github.com/manifoldco/promptui"
 	"github.com/spf13/cobra"
 
 	"test-pcap/pkg/analyzer"
@@ -13,6 +20,7 @@ var version = "dev"
 
 func main() {
 	var pcapFile string
+	var replay bool
 
 	rootCmd := &cobra.Command{
 		Use:     "pcapreplay",
@@ -31,6 +39,9 @@ func main() {
 				fmt.Printf("Request %d: %s -> %s %s %s at %s decoded length %d, content-length %d\n",
 					i+1, r.Src, r.Dst, r.Method, r.URL, r.Timestamp.Format(time.RFC3339), r.DecodedLen, r.ContentLen)
 			}
+			if replay {
+				interactiveReplay(results)
+			}
 			return nil
 		},
 	}
@@ -38,7 +49,151 @@ func main() {
 	rootCmd.SetVersionTemplate("pcapreplay version {{.Version}}\n")
 
 	rootCmd.Flags().StringVarP(&pcapFile, "file", "f", "", "path to pcap file")
+	rootCmd.Flags().BoolVarP(&replay, "replay", "r", false, "enter interactive replay mode")
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 	}
+}
+
+// interactiveReplay allows the user to select a captured request and replay it
+// with optional modifications.
+func interactiveReplay(results []analyzer.Result) {
+	for {
+		items := make([]string, len(results))
+		for i, r := range results {
+			items[i] = fmt.Sprintf("%d: %s %s", i+1, r.Method, r.URL)
+		}
+
+		sel := promptui.Select{
+			Label: "Select request to replay",
+			Items: items,
+		}
+		idx, _, err := sel.Run()
+		if err != nil {
+			fmt.Println("selection cancelled")
+			return
+		}
+		r := results[idx]
+
+		host := r.Host
+		if host == "" {
+			host = r.URL
+		}
+		path := r.Path
+
+		prompt := promptui.Prompt{Label: "Host", Default: host}
+		host, _ = prompt.Run()
+		prompt = promptui.Prompt{Label: "Path", Default: path}
+		path, _ = prompt.Run()
+
+		scheme := "http"
+		schemeSel := promptui.Select{Label: "Scheme", Items: []string{"http", "https"}}
+		_, scheme, _ = schemeSel.Run()
+
+		portDefault := "80"
+		if scheme == "https" {
+			portDefault = "443"
+		}
+		prompt = promptui.Prompt{Label: "Port", Default: portDefault}
+		port, _ := prompt.Run()
+
+		skipVerify := false
+		if scheme == "https" {
+			svSel := promptui.Select{Label: "Skip TLS verify?", Items: []string{"no", "yes"}}
+			_, ans, _ := svSel.Run()
+			if ans == "yes" {
+				skipVerify = true
+			}
+		}
+
+		req, err := http.ReadRequest(bufio.NewReader(bytes.NewReader(r.Raw)))
+		if err != nil {
+			fmt.Println("parse request failed:", err)
+			return
+		}
+		bodyBytes, _ := io.ReadAll(req.Body)
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		req.ContentLength = int64(len(bodyBytes))
+		req.URL.Scheme = scheme
+		req.URL.Host = net.JoinHostPort(host, port)
+		req.Host = host
+		req.URL.Path = path
+
+		resp, info, err := sendRequest(req, scheme, host, port, skipVerify)
+		if err != nil {
+			fmt.Println("replay failed:", err)
+		} else {
+			defer resp.Body.Close()
+			body, _ := io.ReadAll(resp.Body)
+			fmt.Printf("DNS lookup took %v, ip %s\n", info.DNS, info.IP)
+			fmt.Printf("TCP local addr %s, handshake %v\n", info.LocalAddr, info.TCP)
+			if scheme == "https" {
+				fmt.Printf("TLS handshake %v\n", info.TLS)
+			}
+			fmt.Printf("Session time %v\n", info.Session)
+			fmt.Printf("HTTP/%d.%d %s\n", resp.ProtoMajor, resp.ProtoMinor, resp.Status)
+			for k, vals := range resp.Header {
+				for _, v := range vals {
+					fmt.Printf("%s: %s\n", k, v)
+				}
+			}
+			fmt.Printf("\n%s\n", string(body))
+		}
+
+		againSel := promptui.Select{Label: "Replay another?", Items: []string{"no", "yes"}}
+		_, again, _ := againSel.Run()
+		if again != "yes" {
+			return
+		}
+	}
+}
+
+type replayInfo struct {
+	DNS       time.Duration
+	IP        string
+	LocalAddr string
+	TCP       time.Duration
+	TLS       time.Duration
+	Session   time.Duration
+}
+
+func sendRequest(req *http.Request, scheme, host, port string, skipVerify bool) (*http.Response, replayInfo, error) {
+	var info replayInfo
+	start := time.Now()
+	ips, err := net.LookupIP(host)
+	info.DNS = time.Since(start)
+	if err == nil && len(ips) > 0 {
+		info.IP = ips[0].String()
+	}
+	target := host
+	if info.IP != "" {
+		target = info.IP
+	}
+	d := &net.Dialer{}
+	start = time.Now()
+	conn, err := d.Dial("tcp", net.JoinHostPort(target, port))
+	info.TCP = time.Since(start)
+	if err != nil {
+		return nil, info, err
+	}
+	info.LocalAddr = conn.LocalAddr().String()
+
+	var rw net.Conn = conn
+	if scheme == "https" {
+		tlsStart := time.Now()
+		tconn := tls.Client(conn, &tls.Config{ServerName: host, InsecureSkipVerify: skipVerify})
+		if err := tconn.Handshake(); err != nil {
+			return nil, info, err
+		}
+		info.TLS = time.Since(tlsStart)
+		rw = tconn
+	}
+
+	start = time.Now()
+	if err := req.Write(rw); err != nil {
+		return nil, info, err
+	}
+	resp, err := http.ReadResponse(bufio.NewReader(rw), req)
+	info.Session = time.Since(start)
+	return resp, info, err
 }

--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,13 @@ go 1.23.8
 require (
 	github.com/golang/snappy v1.0.0
 	github.com/google/gopacket v1.1.19
+	github.com/manifoldco/promptui v0.9.0
+	github.com/spf13/cobra v1.9.1
 )
 
 require (
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/spf13/cobra v1.9.1 // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859 // indirect
 	golang.org/x/sys v0.0.0-20190412213103-97732733099d // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,9 @@
+github.com/chzyer/logex v1.1.10 h1:Swpa1K6QvQznwJRcfTfQJmTE72DqScAa40E+fbHEXEE=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1 h1:q763qf9huN11kDQavWsoZXJNW3xEE4JJyHa5Q25/sd8=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -5,6 +11,8 @@ github.com/google/gopacket v1.1.19 h1:ves8RnFZPGiFnTS0uPQStjwru6uO6h+nlr9j6fL7kF
 github.com/google/gopacket v1.1.19/go.mod h1:iJ8V8n6KS+z2U1A8pUwu8bW5SyEMkXJB8Yo/Vo+TKTo=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
+github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.9.1 h1:CXSaggrXdbHK9CF+8ywj8Amf7PBRmPCOJugH954Nnlo=
 github.com/spf13/cobra v1.9.1/go.mod h1:nDyEzZ8ogv936Cinf6g1RU9MRY64Ir93oCnqb9wxYW0=
@@ -18,6 +26,7 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d h1:+R4KGOnez64A81RvjARKc4UT5/tI9ujCIVX+P5KiHuI=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/analyzer/analyzer.go
+++ b/pkg/analyzer/analyzer.go
@@ -17,11 +17,19 @@ import (
 )
 
 // Result describes information extracted from a single HTTP request.
+// Result describes information extracted from a single HTTP request.
+// In addition to basic metadata it also keeps the raw request
+// so that it can be replayed later.
 type Result struct {
 	Src        string
 	Dst        string
 	Method     string
 	URL        string
+	Host       string
+	Path       string
+	Headers    string
+	Body       []byte
+	Raw        []byte
 	Timestamp  time.Time
 	DecodedLen int
 	ContentLen int
@@ -106,11 +114,17 @@ func Analyze(file string) ([]Result, int, error) {
 			if req.host != "" {
 				url = req.host + req.path
 			}
+			raw := append([]byte(req.headers+"\r\n\r\n"), req.body...)
 			results = append(results, Result{
 				Src:        k.src,
 				Dst:        k.dst,
 				Method:     req.method,
 				URL:        url,
+				Host:       req.host,
+				Path:       req.path,
+				Headers:    req.headers,
+				Body:       req.body,
+				Raw:        raw,
 				Timestamp:  cd.start,
 				DecodedLen: len(decoded),
 				ContentLen: req.contentLength,

--- a/pkg/analyzer/analyzer_test.go
+++ b/pkg/analyzer/analyzer_test.go
@@ -16,4 +16,7 @@ func TestAnalyze(t *testing.T) {
 	if results[0].DecodedLen != results[0].ContentLen {
 		t.Errorf("decoded length mismatch: %d vs %d", results[0].DecodedLen, results[0].ContentLen)
 	}
+	if len(results[0].Body) != results[0].ContentLen {
+		t.Errorf("body length mismatch: %d vs %d", len(results[0].Body), results[0].ContentLen)
+	}
 }


### PR DESCRIPTION
## Summary
- store raw HTTP data for replay
- add `--replay` flag
- implement interactive session replay using `promptui`
- capture DNS, TCP and TLS timing when replaying
- update tests

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6871720c2240832ab2759b7413e61792